### PR TITLE
Feat: CircleCI for managed deploys

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,23 @@
+version: 2.1
+orbs:
+  node: circleci/node@3.0.0
+jobs:
+  deploy-production:
+    docker:
+      - image: circleci/node:latest
+    steps:
+      - run: curl -X POST -d {} https://api.netlify.com/build_hooks/5fbbe88ab716fa0093e9e36a?trigger_branch=main
+  deploy-staging:
+    docker:
+      - image: circleci/node:latest
+    steps:
+      - run: curl -X POST -d {} https://api.netlify.com/build_hooks/5fbbe88ab716fa0093e9e36a?trigger_branch=staging
+workflows:
+  deploy:
+    jobs:
+      - deploy-staging
+      - deploy-production:
+          filters:
+            branches:
+              only:
+                - main


### PR DESCRIPTION
Add's CircleCI config to manage what webhook to deploy when commiting to either the `main` or `staging` branches. 